### PR TITLE
Moved script tag from head to closing body tag

### DIFF
--- a/html/temp.sublime-snippet
+++ b/html/temp.sublime-snippet
@@ -8,11 +8,11 @@
 <head>
 	<title> $3 </title>
 	<meta charset="utf-8" />
-	<script src:"js/scripts.js"></script>
 	<link rel="stylesheet" href="css/styles.css"/>
 </head>
 <body>
 $0
+<script src='js/scripts.js'></script>
 </body>
 </html>]]></content>
 	<tabTrigger>temp</tabTrigger>


### PR DESCRIPTION
Never put script tags in the head unless you really need to (e.g Google WebFont Loader / Typekit) or they need to be initialised before rendering the page.

ref: https://developer.yahoo.com/performance/rules.html#js_bottom
